### PR TITLE
Better pre-release versioning

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
     
     - uses: docker/build-push-action@v2.9.0
       name: Prepare pre-release packages
-      if: ${{ github.ref }} != 'refs/heads/main'
+      if: github.ref != 'refs/heads/main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages
@@ -67,7 +67,7 @@ jobs:
         
     - uses: docker/build-push-action@v2.9.0
       name: Prepare packages
-      if: ${{ github.ref }} == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,11 +58,22 @@ jobs:
     
     - uses: docker/build-push-action@v2.9.0
       id: package
-      name: Prepare packages
+      name: Prepare pre-release packages
+      if: ${{ github.ref_name }} != 'main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages
-        build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
+        build-args: Version=${{ steps.gitversion.outputs.SemVer }}${{ steps.gitversion.outputs.PreReleaseLabelWithDash }}.${{ github.run_number }}
+        outputs: type=local,dest=${{ github.workspace }}
+        
+    - uses: docker/build-push-action@v2.9.0
+      id: package
+      name: Prepare packages
+      if: ${{ github.ref_name }} == 'main'
+      with:
+        file: .github/workflows/build.Dockerfile
+        target: export-packages
+        build-args: Version=${{ steps.gitversion.outputs.SemVer }}
         outputs: type=local,dest=${{ github.workspace }}
 
     - name: Upload nupkg files

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: build-and-test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, prerelease ]
   pull_request:
-    branches: [ main ] 
+    branches: [ main, prerelease ] 
 
 jobs:
   build:
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      # Used later for calculating GitVersion
+      with:
+        fetch-depth: 0 
 
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v1.6.0
@@ -44,32 +47,40 @@ jobs:
       if: ${{ always() }}
       
     # Build and push packages           
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.13
+      with:
+        versionSpec: '5.x'
+        
+    - name: Determine Version
+      id:   gitversion
+      uses: gittools/actions/gitversion/execute@v0.9.13
+    
     - uses: docker/build-push-action@v2.9.0
       id: package
       name: Prepare packages
-      if: github.event_name != 'pull_request'
       with:
         file: .github/workflows/build.Dockerfile
-        tags: gaip-net/packages:latest
-        target: dotnet-pack
-        build-args: Version=0.0.1-alpha.${{ github.run_number }} 
-        load: true
-      
-    - name: Push to Nuget
-      if: steps.package.outcome == 'success'
-      run : |
-        docker run --name pack gaip-net/packages:latest dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
-        
-    - name: Copy nupkg files
-      id: copy-nupkgs
-      if: steps.package.outcome == 'success'
-      run : |
-        docker cp pack:/output ${{ github.workspace }}/nupkgs
-        
+        target: export-packages
+        build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
+        outputs: type=local,dest=${{ github.workspace }}
+
     - name: Upload nupkg files
-      if: steps.copy-nupkgs.outcome == 'success'
+      if: steps.package.outcome == 'success'
       uses: actions/upload-artifact@v3
       with:
         name: nuget-packages
         path: ${{ github.workspace }}/nupkgs
-      
+
+      # Only push on actual builds, not on PRs
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      with:
+        dotnet-version: |
+          6.0.x
+
+    - name: Push to Nuget
+      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      run: |
+        dotnet nuget push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,16 +58,16 @@ jobs:
     
     - uses: docker/build-push-action@v2.9.0
       name: Prepare pre-release packages
-      if: ${{ github.ref_name }} != 'main'
+      if: ${{ github.ref }} != 'refs/heads/main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages
-        build-args: Version=${{ steps.gitversion.outputs.SemVer }}-rc.${{ github.run_number }}
+        build-args: Version=${{ steps.gitversion.outputs.MajorMinorPatch }}-rc.${{ github.run_number }}
         outputs: type=local,dest=${{ github.workspace }}
         
     - uses: docker/build-push-action@v2.9.0
       name: Prepare packages
-      if: ${{ github.ref_name }} == 'main'
+      if: ${{ github.ref }} == 'refs/heads/main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,17 +57,15 @@ jobs:
       uses: gittools/actions/gitversion/execute@v0.9.13
     
     - uses: docker/build-push-action@v2.9.0
-      id: package
       name: Prepare pre-release packages
       if: ${{ github.ref_name }} != 'main'
       with:
         file: .github/workflows/build.Dockerfile
         target: export-packages
-        build-args: Version=${{ steps.gitversion.outputs.SemVer }}${{ steps.gitversion.outputs.PreReleaseLabelWithDash }}.${{ github.run_number }}
+        build-args: Version=${{ steps.gitversion.outputs.SemVer }}-rc.${{ github.run_number }}
         outputs: type=local,dest=${{ github.workspace }}
         
     - uses: docker/build-push-action@v2.9.0
-      id: package
       name: Prepare packages
       if: ${{ github.ref_name }} == 'main'
       with:
@@ -77,7 +75,6 @@ jobs:
         outputs: type=local,dest=${{ github.workspace }}
 
     - name: Upload nupkg files
-      if: steps.package.outcome == 'success'
       uses: actions/upload-artifact@v3
       with:
         name: nuget-packages
@@ -86,12 +83,12 @@ jobs:
       # Only push on actual builds, not on PRs
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
-      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       with:
         dotnet-version: |
           6.0.x
 
     - name: Push to Nuget
-      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       run: |
         dotnet nuget push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.Dockerfile
+++ b/.github/workflows/build.Dockerfile
@@ -45,4 +45,4 @@ RUN dotnet pack ./src/Gaip.Net.Linq/Gaip.Net.Linq.csproj --no-build --output /ou
 
 # Build stage for exporting locally. Not used in build pipelines for now.
 FROM scratch AS export-packages
-COPY --from=dotnet-pack /output .
+COPY --from=dotnet-pack /output /nupkgs

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,1 +1,1 @@
-DOCKER_BUILDKIT=1 docker build -f ./.github/workflows/build.Dockerfile .  --build-arg Version="$1" --target export-packages --output output 
+docker buildx build -f ./.github/workflows/build.Dockerfile . --build-arg Version="$1" --target export-packages --output type=local,dest=. 


### PR DESCRIPTION
Semver for prereleases will be:

`0.1.0-rc.53`, where 53 will be the run number that built the package. Then we can correlate easier.